### PR TITLE
Add newsletter subscription backend and footer form

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,6 +73,7 @@ def _sqlalchemy_url():
     return "sqlite:///local.db"
 
 ENGINE = create_engine(_sqlalchemy_url(), pool_pre_ping=True, future=True)
+app.config["DB_ENGINE"] = ENGINE
 
 # -------------- Template helpers --------------
 @app.context_processor
@@ -250,6 +251,9 @@ app.register_blueprint(bootcamp_bp, url_prefix="/bootcamp")
 
 from price import price_bp
 app.register_blueprint(price_bp, url_prefix="/price")
+
+from subscriptions import subscription_bp
+app.register_blueprint(subscription_bp)
 
 @app.get("/renovation")
 def renovation():

--- a/subscriptions.py
+++ b/subscriptions.py
@@ -1,0 +1,182 @@
+"""Subscription management endpoints."""
+
+import logging
+import secrets
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from flask import Blueprint, current_app, jsonify, redirect, request
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+
+log = logging.getLogger("aiforimpact-subscriptions")
+
+subscription_bp = Blueprint("subscription", __name__, url_prefix="/subscribe")
+
+
+def _coerce_bool(value: Any) -> Optional[bool]:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)) and value:
+        value = value[0]
+    if isinstance(value, str):
+        value = value.strip().lower()
+        if value in {"1", "true", "yes", "on"}:
+            return True
+        if value in {"0", "false", "no", "off"}:
+            return False
+    return None
+
+
+def _best_client_ip() -> Optional[str]:
+    forwarded = request.headers.get("X-Forwarded-For", "")
+    if forwarded:
+        candidate = forwarded.split(",")[0].strip()
+        if candidate:
+            return candidate
+    remote = request.remote_addr
+    return remote.strip() if remote else None
+
+
+def _want_json() -> bool:
+    if request.is_json:
+        return True
+    accept = request.accept_mimetypes
+    if accept and accept.best == "application/json":
+        return True
+    if request.headers.get("X-Requested-With", "").lower() == "xmlhttprequest":
+        return True
+    return False
+
+
+@subscription_bp.post("/")
+def create_subscription():
+    """Create or update a subscription record for the provided email."""
+    engine = current_app.config.get("DB_ENGINE")
+    if engine is None:
+        log.error("Database engine unavailable when creating subscription")
+        return jsonify({"ok": False, "error": "unavailable"}), 500
+
+    payload: Dict[str, Any]
+    if request.is_json:
+        payload = request.get_json(silent=True) or {}
+    else:
+        payload = request.form.to_dict(flat=False)
+        payload = {k: (v[0] if isinstance(v, list) else v) for k, v in payload.items()}
+
+    email = (payload.get("email") or "").strip().lower()
+    plan_code = (payload.get("plan_code") or payload.get("plan") or "newsletter").strip()
+    locale = (payload.get("locale") or request.accept_languages.best or "").strip() or None
+    consent_marketing = _coerce_bool(payload.get("consent_marketing"))
+    tags = payload.get("tags")
+    if isinstance(tags, str):
+        tags = [t.strip() for t in tags.split(",") if t.strip()]
+    elif not isinstance(tags, (list, tuple)):
+        tags = None
+
+    if not email or "@" not in email:
+        msg = "Please provide a valid email address."
+        if _want_json():
+            return jsonify({"ok": False, "error": msg}), 400
+        return redirect(request.referrer or request.url or "/")
+
+    now = datetime.now(timezone.utc)
+    token = secrets.token_urlsafe(18)
+    status = "subscribed"
+    source = payload.get("source") or "web_form"
+    reason_unsub = None
+
+    ip_address = _best_client_ip()
+    user_agent = request.headers.get("User-Agent")
+
+    params = dict(
+        email=email,
+        plan_code=plan_code or None,
+        status=status,
+        source=source,
+        double_opt_in_token=token,
+        confirmed_at=now,
+        unsubscribed_at=None,
+        reason_unsub=reason_unsub,
+        consent_marketing=consent_marketing,
+        locale=locale,
+        ip_signup=ip_address,
+        user_agent_signup=user_agent,
+        tags=tags,
+        created_at=now,
+        updated_at=now,
+    )
+
+    select_sql = text(
+        """
+        SELECT id, plan_code, status
+        FROM subscriptions
+        WHERE lower(email) = :email
+        ORDER BY created_at DESC
+        LIMIT 1
+        """
+    )
+
+    insert_sql = text(
+        """
+        INSERT INTO subscriptions (
+            email, plan_code, status, source, double_opt_in_token,
+            confirmed_at, unsubscribed_at, reason_unsub, consent_marketing,
+            locale, ip_signup, user_agent_signup, tags, created_at, updated_at
+        ) VALUES (
+            :email, :plan_code, :status, :source, :double_opt_in_token,
+            :confirmed_at, :unsubscribed_at, :reason_unsub, :consent_marketing,
+            :locale, :ip_signup, :user_agent_signup, :tags, :created_at, :updated_at
+        )
+        RETURNING id
+        """
+    )
+
+    update_sql = text(
+        """
+        UPDATE subscriptions
+        SET plan_code = :plan_code,
+            status = :status,
+            source = :source,
+            double_opt_in_token = :double_opt_in_token,
+            confirmed_at = :confirmed_at,
+            unsubscribed_at = :unsubscribed_at,
+            reason_unsub = :reason_unsub,
+            consent_marketing = :consent_marketing,
+            locale = :locale,
+            ip_signup = :ip_signup,
+            user_agent_signup = :user_agent_signup,
+            tags = :tags,
+            updated_at = :updated_at
+        WHERE id = :id
+        RETURNING id
+        """
+    )
+
+    try:
+        with engine.begin() as conn:
+            existing = conn.execute(select_sql, {"email": email}).mappings().first()
+            if existing:
+                params_with_id = dict(params)
+                params_with_id["id"] = existing["id"]
+                result = conn.execute(update_sql, params_with_id)
+                sub_id = result.scalar_one_or_none() or existing["id"]
+                created = False
+            else:
+                result = conn.execute(insert_sql, params)
+                sub_id = result.scalar_one()
+                created = True
+    except SQLAlchemyError as exc:
+        log.exception("Subscription write failed: %s", exc)
+        if _want_json():
+            return jsonify({"ok": False, "error": "internal_error"}), 500
+        return redirect(request.referrer or request.url or "/")
+
+    payload = {"ok": True, "id": sub_id, "created": created}
+    if _want_json():
+        return jsonify(payload)
+
+    target = request.referrer or request.url_root or "/"
+    return redirect(target)

--- a/templates/base.html
+++ b/templates/base.html
@@ -101,7 +101,9 @@
     /* Footer */
     footer.site-footer{border-top:1px solid #1a1f2e;margin-top:32px}
     footer.site-footer .container{padding-top:22px;padding-bottom:22px}
-    .footer-text{text-align:center;color:var(--muted);font-size:14px}
+    .footer-layout{display:flex;flex-wrap:wrap;gap:22px;align-items:flex-start;justify-content:space-between}
+    .footer-copy{flex:1 1 260px;min-width:240px}
+    .footer-text{color:var(--muted);font-size:14px;line-height:1.6;margin:0}
     .footer-text strong{color:var(--ink)}
     .footer-text .no-js-email{white-space:nowrap;font-weight:700;color:var(--ink)}
     .footer-text .js-email{display:none;white-space:nowrap}
@@ -109,6 +111,23 @@
 
     .has-js .footer-text .no-js-email{display:none}
     .has-js .footer-text .js-email{display:inline}
+
+    .subscribe-card{flex:1 1 320px;min-width:280px;background:var(--card);border:1px solid #1a1f2e;border-radius:14px;padding:18px;box-shadow:0 12px 40px rgba(5,10,20,.25)}
+    .subscribe-card h2{margin:0 0 10px;font-size:18px}
+    .subscribe-card p{margin:0 0 16px;color:var(--muted);font-size:14px}
+    .subscribe-form{display:flex;flex-direction:column;gap:12px}
+    .subscribe-row{display:flex;gap:8px;flex-wrap:wrap}
+    .subscribe-row input[type="email"]{flex:1 1 auto;min-width:200px;background:#090b12;border:1px solid #23283a;border-radius:9px;padding:12px 14px;color:var(--ink);font-size:15px}
+    .subscribe-row input[type="email"]:focus{outline:2px solid rgba(92,169,255,.6);outline-offset:1px}
+    .subscribe-button{background:var(--accent);color:#051327;font-weight:700;border:none;border-radius:9px;padding:12px 18px;cursor:pointer;transition:transform .1s ease,box-shadow .2s ease}
+    .subscribe-button:hover{transform:translateY(-1px);box-shadow:0 6px 20px rgba(92,169,255,.35)}
+    .subscribe-button:disabled{opacity:.6;cursor:progress;transform:none;box-shadow:none}
+    .subscribe-consent{display:flex;align-items:flex-start;gap:8px;font-size:13px;color:var(--muted)}
+    .subscribe-consent input{margin-top:3px}
+    .subscribe-feedback{font-size:13px;margin:0;min-height:18px}
+    .subscribe-feedback[hidden]{display:none}
+    .subscribe-feedback.is-error{color:#ff8383}
+    .subscribe-feedback.is-success{color:#8be087}
 
     /* Small-screen adjustments */
     @media (max-width: 720px){
@@ -222,17 +241,105 @@
   </main>
 
   <footer class="site-footer" role="contentinfo" aria-label="Site footer">
-    <div class="container">
-      <p class="footer-text">
-        <strong>Contact us for more information</strong>
-        &nbsp;—&nbsp;
-        <span class="no-js-email">connect&nbsp;[at]&nbsp;aiforimpact&nbsp;[dot]&nbsp;net</span>
-        <span class="js-email" data-b="Y29ubmVjdEBhaWZvcmltcGFjdC5uZXQ=" aria-hidden="true"></span>
-      </p>
+    <div class="container footer-layout">
+      <div class="footer-copy">
+        <p class="footer-text">
+          <strong>Contact us for more information</strong>
+          &nbsp;—&nbsp;
+          <span class="no-js-email">connect&nbsp;[at]&nbsp;aiforimpact&nbsp;[dot]&nbsp;net</span>
+          <span class="js-email" data-b="Y29ubmVjdEBhaWZvcmltcGFjdC5uZXQ=" aria-hidden="true"></span>
+        </p>
+      </div>
+
+      <form class="subscribe-card subscribe-form" method="post" action="{{ bp('/subscribe/') }}" data-subscription-form novalidate>
+        <h2>Subscribe for updates</h2>
+        <p>Be the first to hear about new cohorts, resources, and AI deployment tactics.</p>
+        <div class="subscribe-row">
+          <input type="email" name="email" autocomplete="email" placeholder="you@example.com" required aria-label="Email address">
+          <input type="hidden" name="plan_code" value="newsletter">
+          <button type="submit" class="subscribe-button">Subscribe</button>
+        </div>
+        <label class="subscribe-consent">
+          <input type="checkbox" name="consent_marketing" value="true">
+          <span>I agree to receive occasional marketing emails about Ai For Impact offerings.</span>
+        </label>
+        <p class="subscribe-feedback" data-subscription-feedback hidden role="status"></p>
+      </form>
     </div>
   </footer>
 
   {% block body_end %}{% endblock %}
+
+  <script>
+    (function(){
+      var forms = document.querySelectorAll('[data-subscription-form]');
+      if (!forms.length) return;
+
+      forms.forEach(function(form){
+        var feedback = form.querySelector('[data-subscription-feedback]');
+        var button = form.querySelector('button[type="submit"]');
+
+        function setFeedback(message, kind){
+          if (!feedback) return;
+          feedback.textContent = message || '';
+          feedback.hidden = !message;
+          feedback.classList.remove('is-error', 'is-success');
+          if (kind) feedback.classList.add(kind);
+        }
+
+        form.addEventListener('submit', function(evt){
+          evt.preventDefault();
+          setFeedback('', null);
+
+          var emailInput = form.querySelector('input[name="email"]');
+          if (!emailInput || !emailInput.value || (emailInput.validity && !emailInput.validity.valid)){
+            setFeedback('Enter a valid email to subscribe.', 'is-error');
+            return;
+          }
+
+          var payload = {
+            email: emailInput.value.trim(),
+            plan_code: (form.querySelector('input[name="plan_code"]') || {}).value || 'newsletter'
+          };
+
+          var consentBox = form.querySelector('input[name="consent_marketing"]');
+          if (consentBox) payload.consent_marketing = consentBox.checked;
+
+          if (button) button.disabled = true;
+
+          var action = form.getAttribute('action') || "{{ bp('/subscribe/') }}";
+
+          fetch(action, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Accept': 'application/json',
+              'X-Requested-With': 'XMLHttpRequest'
+            },
+            body: JSON.stringify(payload)
+          }).then(function(resp){
+            if (!resp.ok) throw resp;
+            return resp.json();
+          }).then(function(){
+            setFeedback('Thanks! Please check your inbox for confirmation.', 'is-success');
+            form.reset();
+          }).catch(function(err){
+            var fallbackMsg = 'Something went wrong. Please try again later.';
+            if (err && typeof err.json === 'function') {
+              err.json().then(function(data){
+                var detail = data && (data.error || data.message);
+                setFeedback(detail || fallbackMsg, 'is-error');
+              }).catch(function(){ setFeedback(fallbackMsg, 'is-error'); });
+            } else {
+              setFeedback(fallbackMsg, 'is-error');
+            }
+          }).finally(function(){
+            if (button) button.disabled = false;
+          });
+        });
+      });
+    })();
+  </script>
 
   <!-- Progressive email reveal + active pill highlighting -->
   <script>


### PR DESCRIPTION
## Summary
- add the SQLAlchemy engine to the Flask config and mount a subscription blueprint
- implement a /subscribe endpoint that upserts records in the subscriptions table with request metadata
- add a styled footer subscription form with client-side submission handling

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dec2a25f688331b29723aa9b748e0f