### PR TITLE
Send branded welcome email on subscription

### DIFF
--- a/templates/email/subscription_welcome.html
+++ b/templates/email/subscription_welcome.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en" style="margin:0;padding:0;">
+  <head>
+    <meta charset="utf-8">
+    <title>Welcome to {{ brand_name }}</title>
+  </head>
+  <body style="margin:0;padding:0;background-color:#0b0d12;color:#fafbff;font-family:'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background:linear-gradient(160deg, rgba(11,13,18,0.96) 0%, rgba(20,32,54,0.94) 45%, rgba(10,22,45,0.96) 100%);padding:32px 0;">
+      <tr>
+        <td align="center" style="padding:0 18px;">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width:600px;background-color:#111420;border-radius:18px;border:1px solid #1a2538;box-shadow:0 16px 40px rgba(5,10,20,0.45);overflow:hidden;">
+            <tr>
+              <td style="padding:32px 36px 24px 36px;text-align:center;background:linear-gradient(135deg, rgba(14,24,42,0.92) 0%, rgba(18,34,58,0.92) 60%, rgba(12,28,54,0.96) 100%);border-bottom:1px solid rgba(92,169,255,0.22);">
+                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                  <tr>
+                    <td style="text-align:center;">
+                      {% if brand_logo_url %}
+                      <img src="{{ brand_logo_url }}" alt="{{ brand_name }}" width="72" height="72" style="display:inline-block;border-radius:12px;border:1px solid rgba(92,169,255,0.45);background-color:rgba(8,13,24,0.85);padding:6px;">
+                      {% endif %}
+                      <h1 style="margin:18px 0 8px 0;font-size:26px;line-height:1.24;font-weight:800;color:#f2f6ff;letter-spacing:0.4px;">
+                        Welcome to {{ brand_name }}
+                      </h1>
+                      <p style="margin:0;font-size:16px;line-height:1.6;color:rgba(219,230,255,0.88);">
+                        Thank you for subscribing to {{ plan_display }}. We are excited to have you with us.
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:32px 36px 12px 36px;">
+                <p style="margin:0 0 18px 0;font-size:16px;line-height:1.7;color:#e4ebff;">
+                  Hi there,
+                </p>
+                <p style="margin:0 0 18px 0;font-size:15px;line-height:1.7;color:#b9c4d9;">
+                  Every week we send practical guidance on applying AI for humanitarian and social impact—frameworks, playbooks, and real-world project notes from the Ai For Impact studio.
+                </p>
+                <p style="margin:0 0 24px 0;font-size:15px;line-height:1.7;color:#b9c4d9;">
+                  Keep an eye on your inbox for resources crafted for operators like you. If there’s anything specific you’d like to learn or build, just reply to this email—we read every message.
+                </p>
+                <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin:0 auto 24px auto;">
+                  <tr>
+                    <td>
+                      <a href="{{ site_url }}" style="display:inline-block;padding:14px 24px;border-radius:999px;background-color:{{ accent_color }};color:#051327;font-weight:700;font-size:15px;text-decoration:none;letter-spacing:0.2px;">
+                        Explore Ai For Impact →
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+                <p style="margin:0 0 18px 0;font-size:14px;line-height:1.6;color:#8693aa;">
+                  Warmly,<br>
+                  The {{ brand_name }} team
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:24px 36px 32px 36px;background-color:#101726;border-top:1px solid rgba(92,169,255,0.18);">
+                <p style="margin:0;font-size:12px;line-height:1.5;color:#6f7a92;">
+                  You’re receiving this email because {{ recipient_email }} opted in for updates from {{ brand_name }}.
+                  If this wasn’t you or you prefer not to receive these insights, reply to let us know and we’ll make it right.
+                </p>
+                <p style="margin:12px 0 0 0;font-size:12px;line-height:1.5;color:#6f7a92;">
+                  {{ brand_name }} &middot; {{ site_url }}
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/templates/email/subscription_welcome.txt
+++ b/templates/email/subscription_welcome.txt
@@ -1,0 +1,11 @@
+Hi there,
+
+Thank you for subscribing to {{ plan_display }} at {{ brand_name }}.
+
+Every week we share practical guidance on applying AI for humanitarian and social impact—frameworks, playbooks, and project notes from the Ai For Impact studio. Keep an eye on your inbox for resources tailored to operators like you.
+
+If there's anything specific you want to explore, just reply to this email. We read every message and are happy to help.
+
+Warmly,
+The {{ brand_name }} team
+{{ site_url }}


### PR DESCRIPTION
## Summary
- add SMTP-backed welcome email sending to the subscription flow with guards for configuration issues
- create HTML and plain-text welcome templates that mirror the Ai For Impact visual theme

## Testing
- python -m compileall subscriptions.py

------
https://chatgpt.com/codex/tasks/task_e_68ded13df2508331af9ecf09d3271a49