### PR TITLE
Document SMTP configuration requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Main AI For Impact Portal
+
+## SMTP configuration
+
+Outgoing registration and subscription emails require the following environment variables to be set in production and staging deployments:
+
+- `EMAIL_BACKEND` — set to `smtp` to enable SMTP delivery.
+- `SMTP_HOST` — hostname of the SMTP server.
+- `SMTP_PORT` — port of the SMTP server.
+- `SMTP_USERNAME` — username used to authenticate with the SMTP server.
+- `SMTP_PASSWORD` — password or app-specific token used to authenticate.
+- `SMTP_FROM` — display name and address used in the From header.
+
+Provide these values securely (for example via deployment environment variables or your secret manager). Both the registration notification emails and the subscription welcome emails rely on the same credentials, so updating them in one place keeps the services aligned.
+
+After updating the credentials, trigger a test registration or newsletter subscription in staging/production to verify that the welcome email is delivered successfully.

--- a/subscriptions.py
+++ b/subscriptions.py
@@ -14,11 +14,31 @@ from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 
 EMAIL_BACKEND = os.getenv("EMAIL_BACKEND", "smtp").strip().lower()
-SMTP_HOST = os.getenv("SMTP_HOST", "smtp.zoho.com")
-SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
-SMTP_USERNAME = os.getenv("SMTP_USERNAME", "")
-SMTP_PASSWORD = os.getenv("SMTP_PASSWORD", "")
-SMTP_FROM = os.getenv("SMTP_FROM", "Ai For Impact <connect@aiforimpact.net>")
+
+# Reuse the SMTP configuration that powers registration email notifications so the
+# subscription welcome email is delivered with the same credentials. The
+# environment can override these defaults at runtime, which is how production
+# should inject secrets securely.
+try:
+    from registration import (
+        SMTP_HOST as REG_SMTP_HOST,
+        SMTP_PORT as REG_SMTP_PORT,
+        SMTP_USERNAME as REG_SMTP_USERNAME,
+        SMTP_PASSWORD as REG_SMTP_PASSWORD,
+        SMTP_FROM as REG_SMTP_FROM,
+    )
+except Exception:  # pragma: no cover - defensive import guard
+    REG_SMTP_HOST = None
+    REG_SMTP_PORT = None
+    REG_SMTP_USERNAME = None
+    REG_SMTP_PASSWORD = None
+    REG_SMTP_FROM = None
+
+SMTP_HOST = os.getenv("SMTP_HOST") or REG_SMTP_HOST or "smtp.zoho.com"
+SMTP_PORT = int(os.getenv("SMTP_PORT") or REG_SMTP_PORT or 587)
+SMTP_USERNAME = os.getenv("SMTP_USERNAME") or REG_SMTP_USERNAME or ""
+SMTP_PASSWORD = os.getenv("SMTP_PASSWORD") or REG_SMTP_PASSWORD or ""
+SMTP_FROM = os.getenv("SMTP_FROM") or REG_SMTP_FROM or "Ai For Impact <connect@aiforimpact.net>"
 BRAND_NAME = os.getenv("BRAND_NAME", "Ai For Impact")
 BRAND_LOGO_URL = os.getenv("BRAND_LOGO_URL", "https://i.imgur.com/STm5VaG.png")
 PRIMARY_ACCENT = os.getenv("BRAND_ACCENT", "#5ca9ff")


### PR DESCRIPTION
## Summary
- reuse the registration SMTP configuration as defaults for subscription welcome emails so the guard no longer fails when credentials are configured securely
- add SMTP environment variable requirements to the project README for deployment visibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ded7e9ab448331831be1c8f4355bea