### PR TITLE
Remove workflow section from homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -60,8 +60,7 @@
     {% endif %}
 
     <div class="anchor-row">
-      <a href="#services">See our services ↓</a> &nbsp;•&nbsp;
-      <a href="#how-it-works">Understand the workflow ↓</a>
+      <a href="#services">See our services ↓</a>
       {% if course %}&nbsp;•&nbsp;<a href="#curriculum">Review the curriculum ↓</a>{% endif %}
     </div>
   </div>
@@ -91,49 +90,6 @@
   </div>
 </section>
 {% endif %}
-
-<section id="how-it-works" class="section-card" style="margin-top:26px;">
-  <div class="banner">
-    <h1>How the workflow works</h1>
-    <p class="muted">We blend live, tailored sessions with a companion portal so progress is structured, repeatable, and documented.</p>
-  </div>
-
-  <div class="body">
-    <div class="steps-grid">
-      <div class="step-card">
-        <div class="step-head">
-          <div class="step-num">1</div>
-          <div class="step-title">Discovery & Objectives</div>
-        </div>
-        <p class="step-text">We assess your context, constraints, and outcomes. Together we shape a personal plan and select the right tools.</p>
-      </div>
-
-      <div class="step-card">
-        <div class="step-head">
-          <div class="step-num">2</div>
-          <div class="step-title">1-on-1 Working Sessions</div>
-        </div>
-        <p class="step-text">Short, focused calls where we build, iterate, and unblock. Each session moves a real deliverable forward.</p>
-      </div>
-
-      <div class="step-card">
-        <div class="step-head">
-          <div class="step-num">3</div>
-          <div class="step-title">Learning Portal Guidance</div>
-        </div>
-        <p class="step-text">Your portal shows the workflow step-by-step—prompts, code snippets, and checklists—so you can revisit and reuse.</p>
-      </div>
-
-      <div class="step-card">
-        <div class="step-head">
-          <div class="step-num">4</div>
-          <div class="step-title">Deployment & Follow-up</div>
-        </div>
-        <p class="step-text">We package what we built, deploy where needed, and schedule follow-ups to measure results and refine.</p>
-      </div>
-    </div>
-  </div>
-</section>
 
 <section id="partners" class="section-card" style="margin-top:26px;" aria-labelledby="partners-title">
   <div class="banner">


### PR DESCRIPTION
## Summary
- remove the workflow explanation section from the homepage template
- update the hero anchor row to omit the workflow link since the section is gone

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df885423dc833180495cf49bcac604