### PR TITLE
Update homepage course messaging to emphasize tailored training

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ log = logging.getLogger("aiforimpact-default")
 
 BRAND_NAME = os.getenv("BRAND_NAME", "Ai For Impact")
 BRAND_LOGO_URL = os.getenv("BRAND_LOGO_URL", "https://i.imgur.com/STm5VaG.png")
-COURSE_TITLE = os.getenv("COURSE_TITLE", "Advanced AI Utilization and Real-Time Deployment")
+COURSE_TITLE = os.getenv("COURSE_TITLE", "One on one Tailored Training Session")
 COURSE_COVER_URL = os.getenv("COURSE_COVER_URL", "https://i.imgur.com/iIMdWOn.jpeg")
 BASE_PATH = os.getenv("BASE_PATH", "")
 
@@ -211,7 +211,7 @@ def home():
     services = [
         {
             "name": vm["title"],
-            "summary": "A guided curriculum with live build sessions to deploy AI tools inside your organization.",
+            "summary": "One on one tailored training sessions with live build support inside your organization.",
             "href": "#curriculum",
             "cta": "View the curriculum",
         }

--- a/price.py
+++ b/price.py
@@ -4,8 +4,8 @@ from flask import Blueprint, render_template, jsonify
 price_bp = Blueprint("price", __name__)
 
 COURSE_INFO = {
-    "slug": "advanced-ai-utilization",
-    "title": "Advanced AI Utilization and Real-Time Deployment",
+    "slug": "one-on-one-tailored-training",
+    "title": "One on one Tailored Training Session",
     "subtitle": (
         "Private sessions customized to your goals, supported by a guided portal "
         "that documents the workflow step‑by‑step."

--- a/registration.py
+++ b/registration.py
@@ -138,7 +138,7 @@ PROMO_PRICE_FREE_EUR = int(os.getenv("PROMO_PRICE_FREE_EUR", "0"))
 COURSES = [
     {
         "code": "AAI-RTD",
-        "title": "Advanced AI Utilization and Real-Time Deployment",
+        "title": "One on one Tailored Training Session",
         "price_eur": BASE_PRICE_EUR,
         "seat_cap": None,
         "note": "1-on-1 format · €%d" % BASE_PRICE_EUR,


### PR DESCRIPTION
## Summary
- rename the default course title to "One on one Tailored Training Session"
- update the homepage service summary to highlight one on one tailored sessions
- align registration and pricing pages with the new course name and slug

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfa26da7dc8331b7287c8c6519b99d