### PR TITLE
Remove bootcamp audience messaging from home page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -309,14 +309,6 @@
         </ul>
         {% endif %}
 
-        <div class="bootcamp-audience" aria-label="Ideal participants">
-          <h3>Learners who want to ship a real AI project, not just attend a webinar</h3>
-          <p>
-            We surround every mission with expert reviews, live build support, and infrastructure so motivated professionals
-            can launch something real instead of collecting another slide deck.
-          </p>
-        </div>
-
         <div class="bootcamp-how" aria-label="How the bootcamp works">
           <h3>Mission-based sprints designed to produce working AI</h3>
           <ol class="bootcamp-steps">


### PR DESCRIPTION
## Summary
- remove the bootcamp audience messaging from the homepage hero section

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69235131740c8331978aa28666f1529c)