### PR TITLE
Show blog cover images on home page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -257,6 +257,19 @@
     position: relative;
     z-index: 1;
   }
+  .home-blog-cover {
+    margin: -6px -6px 6px;
+    border-radius: 12px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.06);
+    aspect-ratio: 16 / 9;
+  }
+  .home-blog-cover img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
   .home-blog-link:focus-visible {
     outline: 2px solid var(--accent, #6bc7ff);
     outline-offset: 3px;
@@ -522,6 +535,11 @@
           {% else %}
             <div class="home-blog-link" aria-disabled="true" role="presentation">
           {% endif %}
+              {% if post.cover_image_url %}
+                <figure class="home-blog-cover">
+                  <img src="{{ post.cover_image_url }}" alt="Cover image for {{ post.title }}" loading="lazy" decoding="async">
+                </figure>
+              {% endif %}
               <p class="home-blog-meta">
                 {% if post.author %}<span>{{ post.author }}</span>{% endif %}
                 {% if post.author and post.published %}<span aria-hidden="true">•</span>{% endif %}


### PR DESCRIPTION
## Summary
- display blog post cover images on home page cards
- add styling for consistent aspect ratio and presentation of cover photos

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924ac37347083319eb60684766b3674)